### PR TITLE
Fix alignment of about section text

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,7 @@
       .sobre-text {
         flex: 1 1 400px;
         min-width: 280px;
+        text-align: center;
       }
 
       .sobre-text p {


### PR DESCRIPTION
## Summary
- center align the textual content in the about section of index.html

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68589e4e616c83259b46b789934e6ed9